### PR TITLE
逐次行列分解で新規ユーザー、アイテムが来たら自動的にデータサイズを拡張

### DIFF
--- a/eals/eals.py
+++ b/eals/eals.py
@@ -258,10 +258,41 @@ class ElementwiseAlternatingLeastSquares:
             self.item_count,
         )
 
+    def _expand_data(self, u, i):
+        """新規ユーザー、新規アイテムならデータのサイズを拡張する"""
+        extra_count = 100
+        if u >= self.user_count:
+            new_user_count = u + extra_count
+        else:
+            new_user_count = self.user_count
+        if i >= self.item_count:
+            new_item_count = i + extra_count
+        else:
+            new_item_count = self.item_count
+
+        if new_user_count > self.user_count or new_item_count > self.item_count:
+            self.user_items_lil.resize(new_user_count, new_item_count)
+            self.user_items_lil_t.resize(new_item_count, new_user_count)
+            self.W_lil.resize(new_user_count, new_item_count)
+            self.W_lil_t.resize(new_item_count, new_user_count)
+        if new_user_count > self.user_count:
+            adding_user_count = new_user_count - self.user_count
+            # user_count, factors
+            self.U = np.vstack((self.U, np.zeros((adding_user_count, self.U.shape[1]))))
+        if new_item_count > self.item_count:
+            adding_item_count = new_item_count - self.item_count
+            # item_count, factors
+            self.V = np.vstack((self.V, np.zeros((adding_item_count, self.V.shape[1]))))
+            self.Wi = np.append(self.Wi, np.zeros(adding_item_count))
+
+        self.user_count = new_user_count
+        self.item_count = new_item_count
+
     def update_model(self, u, i):
         """データを1件追加してモデルを更新"""
         timer = Timer()
         self._convert_data_for_online_training()
+        self._expand_data(u, i)
         # TODO: 新規ユーザ、新規アイテムに対応できていないのでは？（IndexErrorになるだけ）
         # あらかじめ将来追加されるのユーザ、アイテムの分まで行列確保しておくのであればこれでもよいが…
         self.user_items_lil[u, i] = 1
@@ -322,7 +353,9 @@ class ElementwiseAlternatingLeastSquares:
                 self.reg,
             )
         else:
-            raise NotImplementedError(f"calc_loss() for self._training_mode='{self._training_mode}' is not defined")
+            raise NotImplementedError(
+                f"calc_loss() for self._training_mode='{self._training_mode}' is not defined"
+            )
         return loss
 
 
@@ -441,7 +474,9 @@ def _calc_loss_csr(indptr, indices, data, U, V, SV, w_indptr, w_data, Wi, user_c
             pred = U[u] @ V[i]
             loss += w * ((rating - pred) ** 2)
             loss -= Wi[i] * (pred ** 2)  # for non-missing items
-        loss += SV @ U[u] @ U[u]  # sum of (Wi[i] * (pred ** 2)) for all (= missing + non-missing) items
+        loss += (
+            SV @ U[u] @ U[u]
+        )  # sum of (Wi[i] * (pred ** 2)) for all (= missing + non-missing) items
     return loss
 
 

--- a/eals/run.py
+++ b/eals/run.py
@@ -12,7 +12,7 @@ from .util import create_user_items
 @click.command(help="run MF for all feedback data")
 @click.option("--max-iter", type=int, default=500)
 def main(max_iter):
-    batch_user_items, online_user_items = create_user_items2()
+    batch_user_items, online_user_items = create_user_items1()
     model = ElementwiseAlternatingLeastSquares(
         random_state=8, show_loss=True, max_iter=max_iter
     )
@@ -30,17 +30,13 @@ def create_user_items1():
         user_count=2000,
         item_count=1000,
         data_count=2000 * 20,
-        new_user_count=0,
-        new_item_count=0,
         rating_fn=lambda data_count: (np.random.rand(data_count) * 10 + 2).astype(np.float32),
         random_seed=8,
     )
     online_user_items = create_user_items(
-        user_count=2000,
-        item_count=1000,
-        data_count=100,
-        new_user_count=0,
-        new_item_count=0,
+        user_count=2200,
+        item_count=1100,
+        data_count=1000,
         rating_fn=lambda data_count: (np.random.rand(data_count) * 10 + 2).astype(np.float32),
         random_seed=8,
     )
@@ -55,15 +51,7 @@ def create_user_items2():
         data = json.load(f)
     train_data = data["train_data"]
     test_data = data["test_data"]
-    train_max_user_ind = max([x[0] for x in train_data])
-    train_max_item_ind = max([x[1] for x in train_data])
-    test_max_user_ind = max([x[0] for x in test_data])
-    test_max_item_ind = max([x[1] for x in test_data])
-    print(f"train_max_user_ind={train_max_user_ind}, train_max_item_ind={train_max_item_ind}")
-    print(f"test_max_user_ind={test_max_user_ind}, test_max_item_ind={test_max_item_ind}")
-    max_user_ind = max([train_max_user_ind, test_max_user_ind])
-    max_item_ind = max([train_max_item_ind, test_max_item_ind])
-    batch_user_items = create_csr_matrix(train_data, user_count=max_user_ind + 1, item_count=max_item_ind + 1)
+    batch_user_items = create_csr_matrix(train_data)
     online_user_items = create_csr_matrix(test_data)
     return batch_user_items, online_user_items
 

--- a/eals/util.py
+++ b/eals/util.py
@@ -6,8 +6,6 @@ def create_user_items(
     user_count=2000,
     item_count=1000,
     data_count=2000 * 20,
-    new_user_count=200,
-    new_item_count=100,
     # rating_fn must return a float array of shape (data_count,)
     rating_fn=lambda data_count: (np.random.rand(data_count) * 10 + 2).astype(np.float32),
     random_seed=None,
@@ -17,5 +15,4 @@ def create_user_items(
     data = rating_fn(data_count)
     u = np.random.randint(0, user_count, size=data_count)
     i = np.random.randint(0, item_count, size=data_count)
-    # new_user_count, new_item_countの分だけ新規ユーザ、新規アイテム格納用の余白を持たせておく
-    return sps.csr_matrix((data, (u, i)), shape=(user_count + new_user_count, item_count + new_item_count))
+    return sps.csr_matrix((data, (u, i)), shape=(user_count, item_count))

--- a/tests/test_eals.py
+++ b/tests/test_eals.py
@@ -140,6 +140,42 @@ def test_update_model():
     pass
 
 
+def test_update_model_for_existing_user_and_item():
+    user_items = sps.csc_matrix([[1, 0, 0, 2], [1, 1, 0, 0], [0, 0, 1, 2]])
+    model = ElementwiseAlternatingLeastSquares()
+    model.fit(user_items)
+    model.update_model(2, 3)
+    assert model.user_factors().shape[0] == 3
+    assert model.item_factors().shape[0] == 4
+
+
+def test_update_model_for_new_user():
+    user_items = sps.csc_matrix([[1, 0, 0, 2], [1, 1, 0, 0], [0, 0, 1, 2]])
+    model = ElementwiseAlternatingLeastSquares()
+    model.fit(user_items)
+    model.update_model(3, 3)
+    assert model.user_factors().shape[0] == 103
+    assert model.item_factors().shape[0] == 4
+
+
+def test_update_model_for_new_item():
+    user_items = sps.csc_matrix([[1, 0, 0, 2], [1, 1, 0, 0], [0, 0, 1, 2]])
+    model = ElementwiseAlternatingLeastSquares()
+    model.fit(user_items)
+    model.update_model(2, 4)
+    assert model.user_factors().shape[0] == 3
+    assert model.item_factors().shape[0] == 104
+
+
+def test_update_model_for_new_user_and_item():
+    user_items = sps.csc_matrix([[1, 0, 0, 2], [1, 1, 0, 0], [0, 0, 1, 2]])
+    model = ElementwiseAlternatingLeastSquares()
+    model.fit(user_items)
+    model.update_model(3, 4)
+    assert model.user_factors().shape[0] == 103
+    assert model.item_factors().shape[0] == 104
+
+
 def test_calc_loss_csr():
     # 2 users, 1 item
     user_items = sps.csc_matrix([[1.0], [0.0]])


### PR DESCRIPTION
- NP半年分のデータだと0.3秒程度かかるので、100個余分にサイズを拡張する
- データ形式に応じた拡張方法が必要
  - lil_matrixはresize()で問題ない
  - 2d arrayはresize()だとデータがずれてしまうため、vstack()を使う（append()でも処理時間はほぼ同じだが、vstack()の方が読みやすい）
  - 1d arrayはappend()で問題ない
