### PR TITLE
Change _print_loss()

### DIFF
--- a/eals/eals.py
+++ b/eals/eals.py
@@ -419,7 +419,8 @@ class ElementwiseAlternatingLeastSquares:
         return loss
 
     def _print_loss(self, iter, message, elapsed):
-        loss = self.calc_loss()
+        """Print the loss per nonzero element of user_items"""
+        loss = self.calc_loss() / self.user_items.nnz
         print(f"iter={iter} {message} loss={loss:.4f} ({elapsed:.4f} sec)")
 
     def save(self, file: Union[Path, str], compress: Union[bool, int] = True):


### PR DESCRIPTION
Fix #24.

`calc_loss()`の実装は変えずに、lossを表示するときだけ`user_items.nnz`で割るようにしました。

lossの定義からは、何で割るのが自然なのかは明らかでないと思うので（ユーザ数なのか、アイテム数なのか、ユーザ数xアイテム数なのか、etc.）、まあnnzで割るのでいいのではと思っています。